### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/km/connectors/khoros_boardsConnector.json
+++ b/km/connectors/khoros_boardsConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "61666",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -99,9 +100,5 @@
       "header": "Category ID",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/km/connectors/khoros_categoriesConnector.json
+++ b/km/connectors/khoros_categoriesConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "61666",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": "true"
       }
     },
     "baseSelector": {
@@ -94,9 +95,5 @@
       "header": "Creation Date",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/km/connectors/khoros_conversationsConnector.json
+++ b/km/connectors/khoros_conversationsConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "61666",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -129,9 +130,5 @@
       "header": "Solved",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/km/connectors/khoros_usersConnector.json
+++ b/km/connectors/khoros_usersConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "61666",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -103,9 +104,5 @@
       "header": "Last Name",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
